### PR TITLE
Add check script and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Thank you for considering a contribution to Bitmxr!
+
+Before opening a pull request please ensure that the codebase builds and all checks pass locally. After installing the prerequisites described in [AGENTS.md](AGENTS.md), you can run the full suite with:
+
+```bash
+pnpm run check
+```
+
+This script runs linting, unit tests, end‑to‑end tests, the frontend build, and all Rust formatting and test commands. It mirrors the CI workflow and should complete without errors before you submit your changes.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "tauri": "tauri",
     "lint": "pnpm -r lint",
     "dev": "tauri dev",
-    "build": "tauri build"
+    "build": "tauri build",
+    "check": "pnpm lint && pnpm --filter frontend test -- --run && pnpm --filter frontend exec playwright test && pnpm --filter frontend build && cargo fmt --manifest-path src-tauri/Cargo.toml --all && cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings && cargo test --manifest-path src-tauri/Cargo.toml"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^1.5.4"


### PR DESCRIPTION
## Summary
- add a `check` script running lint, tests, builds and cargo commands
- document how to run it in `CONTRIBUTING.md`

## Testing
- `pnpm run check`

------
https://chatgpt.com/codex/tasks/task_e_6868f38634208328bf5016b4589cc045