### PR TITLE
Fix missing Mantine styles

### DIFF
--- a/packages/frontend/src/main.tsx
+++ b/packages/frontend/src/main.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
 import App from './app';
+import '@mantine/core/styles.css';
+import '@mantine/notifications/styles.css';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary
- import Mantine CSS files after upgrading Mantine to v8

## Testing
- `pnpm lint`
- `pnpm --filter frontend test -- --run`
- `pnpm --filter frontend exec playwright test`
- `pnpm --filter frontend build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_686929519e488328b6cc1a62aa7169e4