### PR TITLE
Add VST3 plugin scanning

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]
@@ -773,6 +774,22 @@ dependencies = [
  "serde",
  "typeid",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -1724,6 +1741,12 @@ dependencies = [
  "bitflags 2.9.1",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -2794,6 +2817,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,6 +3566,19 @@ dependencies = [
  "embed-resource",
  "indexmap 2.10.0",
  "toml",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ cpal = "0.16"
 tauri-build = { version = "2" }
 
 [dev-dependencies]
+tempfile = "3"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/src/audio_engine/plugins.rs
+++ b/src-tauri/src/audio_engine/plugins.rs
@@ -1,4 +1,17 @@
-//! Plugin management placeholder (e.g., VST3 hosting)
+//! Plugin management (e.g., VST3 hosting)
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+/// Representation of a discovered plugin on disk.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Plugin {
+    pub name: String,
+    pub path: PathBuf,
+}
 
 #[derive(Default)]
 pub struct PluginHost {}
@@ -6,5 +19,68 @@ pub struct PluginHost {}
 impl PluginHost {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Scan the system for available VST3 plugins.
+    pub fn scan() -> Vec<Plugin> {
+        let dirs = Self::plugin_dirs();
+        let mut plugins = Vec::new();
+
+        for dir in dirs {
+            if let Ok(entries) = fs::read_dir(&dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().and_then(|e| e.to_str()) == Some("vst3") {
+                        let name = path
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        plugins.push(Plugin { name, path });
+                    }
+                }
+            }
+        }
+
+        plugins
+    }
+
+    fn plugin_dirs() -> Vec<PathBuf> {
+        if let Ok(custom) = env::var("BITMXR_VST3_DIRS") {
+            let delim = if cfg!(windows) { ';' } else { ':' };
+            return custom
+                .split(delim)
+                .filter(|p| !p.is_empty())
+                .map(PathBuf::from)
+                .collect();
+        }
+
+        let mut dirs = Vec::new();
+        #[cfg(target_os = "windows")]
+        {
+            dirs.push(PathBuf::from("C:\\Program Files\\Common Files\\VST3"));
+            if let Ok(appdata) = env::var("APPDATA") {
+                dirs.push(PathBuf::from(appdata).join("VST3"));
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            dirs.push(PathBuf::from("/Library/Audio/Plug-Ins/VST3"));
+            if let Ok(home) = env::var("HOME") {
+                dirs.push(PathBuf::from(home).join("Library/Audio/Plug-Ins/VST3"));
+            }
+        }
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        {
+            if let Ok(home) = env::var("HOME") {
+                dirs.push(PathBuf::from(home).join(".vst3"));
+            }
+            dirs.push(PathBuf::from("/usr/lib/vst3"));
+            dirs.push(PathBuf::from("/usr/local/lib/vst3"));
+        }
+
+        dirs
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod audio_engine;
+pub use audio_engine::plugins::Plugin;
 
 /// Return placeholder audio statistics used by the Tauri commands.
 pub fn get_audio_stats() -> String {
@@ -13,4 +14,9 @@ pub fn list_audio_devices() -> Vec<String> {
 /// Set the application's active audio device by identifier.
 pub fn set_audio_device(id: &str) {
     audio_engine::devices::DeviceManager::set_default(id);
+}
+
+/// Discover available plugins on the system.
+pub fn list_plugins() -> Vec<Plugin> {
+    audio_engine::plugins::PluginHost::scan()
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,7 +2,8 @@
 
 use bitmxr::{
     audio_engine::AudioEngine, get_audio_stats as get_audio_stats_impl,
-    list_audio_devices as list_audio_devices_impl, set_audio_device as set_audio_device_impl,
+    list_audio_devices as list_audio_devices_impl, list_plugins as list_plugins_impl,
+    set_audio_device as set_audio_device_impl, Plugin,
 };
 
 #[tauri::command]
@@ -13,6 +14,11 @@ fn get_audio_stats() -> String {
 #[tauri::command]
 fn list_audio_devices() -> Vec<String> {
     list_audio_devices_impl()
+}
+
+#[tauri::command]
+fn list_plugins() -> Vec<Plugin> {
+    list_plugins_impl()
 }
 
 #[tauri::command]
@@ -27,7 +33,8 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             get_audio_stats,
             list_audio_devices,
-            set_audio_device
+            set_audio_device,
+            list_plugins
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/tests/plugins.rs
+++ b/src-tauri/tests/plugins.rs
@@ -1,0 +1,11 @@
+use bitmxr::list_plugins;
+use std::env;
+
+#[test]
+fn empty_dirs_yield_empty_vec() {
+    let dir = tempfile::tempdir().unwrap();
+    env::set_var("BITMXR_VST3_DIRS", dir.path());
+    let plugins = list_plugins();
+    env::remove_var("BITMXR_VST3_DIRS");
+    assert!(plugins.is_empty());
+}


### PR DESCRIPTION
## Summary
- implement Plugin struct and scanning logic
- expose list_plugins helper and tauri command
- add tests for plugin scanning

## Testing
- `pnpm lint`
- `pnpm --filter frontend test -- --run`
- `pnpm --filter frontend exec playwright test`
- `pnpm --filter frontend build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68692afcd4088328b572f76b1dbc8739