### PR TITLE
Add plugin listing UI

### DIFF
--- a/packages/frontend/src/__tests__/PluginList.test.tsx
+++ b/packages/frontend/src/__tests__/PluginList.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { MantineProvider } from '@mantine/core';
+import PluginList from '../components/PluginList';
+import { invoke } from '@tauri-apps/api/core';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+const mockedInvoke = vi.mocked(invoke);
+
+describe('PluginList', () => {
+  beforeAll(() => {
+    class RO {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    // @ts-expect-error -- polyfill for testing
+    global.ResizeObserver = RO;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it('renders plugins from invoke', async () => {
+    mockedInvoke.mockResolvedValueOnce([
+      { name: 'Test', path: '/test.vst3' },
+    ]);
+    render(
+      <MantineProvider>
+        <PluginList />
+      </MantineProvider>
+    );
+    expect(await screen.findByText('Test')).toBeTruthy();
+    expect(screen.getByText('/test.vst3')).toBeTruthy();
+  });
+
+  it('rescans when button clicked', async () => {
+    mockedInvoke.mockResolvedValueOnce([]);
+    render(
+      <MantineProvider>
+        <PluginList />
+      </MantineProvider>
+    );
+
+    mockedInvoke.mockResolvedValueOnce([
+      { name: 'Other', path: '/other.vst3' },
+    ]);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /rescan/i })[0]);
+    expect(await screen.findByText('Other')).toBeTruthy();
+  });
+});

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -2,6 +2,7 @@ import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { Routes, Route } from 'react-router-dom';
 import Home from './routes/home';
+import PluginList from './components/PluginList';
 
 export default function App() {
   return (
@@ -9,6 +10,7 @@ export default function App() {
       <Notifications />
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/plugins" element={<PluginList />} />
       </Routes>
     </MantineProvider>
   );

--- a/packages/frontend/src/components/PluginList.tsx
+++ b/packages/frontend/src/components/PluginList.tsx
@@ -1,0 +1,56 @@
+import { Button, Table, Text } from '@mantine/core';
+import { invoke } from '@tauri-apps/api/core';
+import { useEffect, useState } from 'react';
+
+export interface Plugin {
+  name: string;
+  path: string;
+}
+
+export default function PluginList() {
+  const [plugins, setPlugins] = useState<Plugin[]>([]);
+
+  const fetchPlugins = async () => {
+    try {
+      const result = await invoke<Plugin[]>('list_plugins');
+      setPlugins(result);
+    } catch {
+      // ignore invoke errors in non-tauri environments
+    }
+  };
+
+  useEffect(() => {
+    fetchPlugins();
+  }, []);
+
+  return (
+    <div>
+      <Button onClick={fetchPlugins} className="mb-2">
+        Rescan
+      </Button>
+      <Table withTableBorder withColumnBorders>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>Name</Table.Th>
+            <Table.Th>Path</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {plugins.map((p) => (
+            <Table.Tr key={p.path}>
+              <Table.Td>{p.name}</Table.Td>
+              <Table.Td>{p.path}</Table.Td>
+            </Table.Tr>
+          ))}
+          {plugins.length === 0 && (
+            <Table.Tr>
+              <Table.Td colSpan={2}>
+                <Text c="dimmed">No plugins found</Text>
+              </Table.Td>
+            </Table.Tr>
+          )}
+        </Table.Tbody>
+      </Table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add PluginList component fetching the new `list_plugins` command
- add PluginList unit tests
- expose `/plugins` route to render PluginList

## Testing
- `pnpm lint`
- `pnpm --filter frontend test -- --run`
- `pnpm --filter frontend exec playwright test`
- `pnpm --filter frontend build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68693352a55883289ddb702da25f66a2