### PR TITLE
Add VST3 metadata scanning

### DIFF
--- a/packages/frontend/src/__tests__/PluginList.test.tsx
+++ b/packages/frontend/src/__tests__/PluginList.test.tsx
@@ -34,7 +34,12 @@ describe('PluginList', () => {
 
   it('renders plugins from invoke', async () => {
     mockedInvoke.mockResolvedValueOnce([
-      { name: 'Test', path: '/test.vst3' },
+      {
+        name: 'Test',
+        vendor: 'Vend',
+        version: '1.0.0',
+        path: '/test.vst3',
+      },
     ]);
     render(
       <MantineProvider>
@@ -42,6 +47,8 @@ describe('PluginList', () => {
       </MantineProvider>
     );
     expect(await screen.findByText('Test')).toBeTruthy();
+    expect(screen.getByText('Vend')).toBeTruthy();
+    expect(screen.getByText('1.0.0')).toBeTruthy();
     expect(screen.getByText('/test.vst3')).toBeTruthy();
   });
 
@@ -54,7 +61,12 @@ describe('PluginList', () => {
     );
 
     mockedInvoke.mockResolvedValueOnce([
-      { name: 'Other', path: '/other.vst3' },
+      {
+        name: 'Other',
+        vendor: 'Vend',
+        version: '0.0.1',
+        path: '/other.vst3',
+      },
     ]);
 
     fireEvent.click(screen.getAllByRole('button', { name: /rescan/i })[0]);

--- a/packages/frontend/src/components/PluginList.tsx
+++ b/packages/frontend/src/components/PluginList.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 
 export interface Plugin {
   name: string;
+  vendor: string;
+  version: string;
   path: string;
 }
 
@@ -32,6 +34,8 @@ export default function PluginList() {
         <Table.Thead>
           <Table.Tr>
             <Table.Th>Name</Table.Th>
+            <Table.Th>Vendor</Table.Th>
+            <Table.Th>Version</Table.Th>
             <Table.Th>Path</Table.Th>
           </Table.Tr>
         </Table.Thead>
@@ -39,12 +43,14 @@ export default function PluginList() {
           {plugins.map((p) => (
             <Table.Tr key={p.path}>
               <Table.Td>{p.name}</Table.Td>
+              <Table.Td>{p.vendor}</Table.Td>
+              <Table.Td>{p.version}</Table.Td>
               <Table.Td>{p.path}</Table.Td>
             </Table.Tr>
           ))}
           {plugins.length === 0 && (
             <Table.Tr>
-              <Table.Td colSpan={2}>
+              <Table.Td colSpan={4}>
                 <Text c="dimmed">No plugins found</Text>
               </Table.Td>
             </Table.Tr>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -160,6 +160,7 @@ name = "bitmxr"
 version = "0.1.0"
 dependencies = [
  "cpal",
+ "plist",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 cpal = "0.16"
+plist = "1"
 
 [build-dependencies]
 tauri-build = { version = "2" }

--- a/src-tauri/tests/plugins.rs
+++ b/src-tauri/tests/plugins.rs
@@ -9,3 +9,37 @@ fn empty_dirs_yield_empty_vec() {
     env::remove_var("BITMXR_VST3_DIRS");
     assert!(plugins.is_empty());
 }
+
+#[test]
+fn reads_vst3_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let bundle = dir.path().join("Test.vst3").join("Contents");
+    std::fs::create_dir_all(&bundle).unwrap();
+    std::fs::write(
+        bundle.join("Info.plist"),
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>TestPlugin</string>
+    <key>Manufacturer</key>
+    <string>TestVendor</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+</dict>
+</plist>
+"#,
+    )
+    .unwrap();
+
+    env::set_var("BITMXR_VST3_DIRS", dir.path());
+    let plugins = list_plugins();
+    env::remove_var("BITMXR_VST3_DIRS");
+
+    assert_eq!(plugins.len(), 1);
+    let p = &plugins[0];
+    assert_eq!(p.name, "TestPlugin");
+    assert_eq!(p.vendor, "TestVendor");
+    assert_eq!(p.version, "0.1.0");
+}


### PR DESCRIPTION
## Summary
- gather VST3 plugin metadata from `Info.plist`
- expose vendor and version on `Plugin` struct
- show vendor and version in the UI
- update unit tests and add metadata test

## Testing
- `pnpm lint`
- `pnpm --filter frontend test -- --run`
- `pnpm --filter frontend exec playwright test`
- `pnpm --filter frontend build`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68693e6bd2608328ad452228267bcbb9