### PR TITLE
Improve audio engine docs

### DIFF
--- a/src-tauri/src/audio_engine/devices.rs
+++ b/src-tauri/src/audio_engine/devices.rs
@@ -8,11 +8,18 @@ pub struct DeviceManager {}
 static DEFAULT_DEVICE: OnceLock<Mutex<Option<String>>> = OnceLock::new();
 
 impl DeviceManager {
+    /// Create a new [`DeviceManager`].
+    ///
+    /// # Returns
+    /// A manager instance with no additional state.
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Return the names of available input and output audio devices using `cpal`.
+    ///
+    /// # Returns
+    /// A list of device identifiers in a displayable form.
     pub fn list() -> Vec<String> {
         use cpal::traits::{DeviceTrait, HostTrait};
 
@@ -39,12 +46,22 @@ impl DeviceManager {
     }
 
     /// Set the default audio device identifier used by the application.
+    ///
+    /// The identifier is stored in a process wide static and remains in memory
+    /// until the application exits.
+    ///
+    /// # Arguments
+    /// * `id` - The identifier previously returned from [`Self::list`].
     pub fn set_default(id: &str) {
         let lock = DEFAULT_DEVICE.get_or_init(|| Mutex::new(None));
         *lock.lock().unwrap() = Some(id.to_string());
     }
 
     /// Retrieve the currently selected audio device identifier, if any.
+    ///
+    /// # Returns
+    /// `Some(String)` containing the identifier set with [`set_default`], or
+    /// `None` if no device has been selected.
     pub fn current() -> Option<String> {
         DEFAULT_DEVICE
             .get_or_init(|| Mutex::new(None))

--- a/src-tauri/src/audio_engine/plugins.rs
+++ b/src-tauri/src/audio_engine/plugins.rs
@@ -20,11 +20,21 @@ pub struct Plugin {
 pub struct PluginHost {}
 
 impl PluginHost {
+    /// Create a new [`PluginHost`].
+    ///
+    /// # Returns
+    /// A host instance with no plugins loaded.
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Scan the system for available VST3 plugins.
+    ///
+    /// The directories searched are platform specific and may also be
+    /// overridden using the `BITMXR_VST3_DIRS` environment variable.
+    ///
+    /// # Returns
+    /// A collection of [`Plugin`] entries describing each discovered plugin.
     pub fn scan() -> Vec<Plugin> {
         let dirs = Self::plugin_dirs();
         let mut plugins = Vec::new();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,21 +2,42 @@ pub mod audio_engine;
 pub use audio_engine::plugins::Plugin;
 
 /// Return placeholder audio statistics used by the Tauri commands.
+///
+/// This helper currently returns a static string describing the sample rate and
+/// buffer size. The values are not queried from the audio engine and should be
+/// treated as placeholders.
+///
+/// # Returns
+/// A [`String`] containing human readable statistics.
 pub fn get_audio_stats() -> String {
     "Sample Rate: 44100, Buffer Size: 512".into()
 }
 
 /// List available audio device names using [`cpal`].
+///
+/// # Returns
+/// A list of device identifiers for both input and output devices that were
+/// discovered on the host system.
 pub fn list_audio_devices() -> Vec<String> {
     audio_engine::devices::DeviceManager::list()
 }
 
 /// Set the application's active audio device by identifier.
+///
+/// The selected identifier is stored internally for the lifetime of the
+/// application and will be returned from [`DeviceManager::current`].
+///
+/// # Arguments
+/// * `id` - Identifier returned from [`list_audio_devices`].
 pub fn set_audio_device(id: &str) {
     audio_engine::devices::DeviceManager::set_default(id);
 }
 
 /// Discover available plugins on the system.
+///
+/// # Returns
+/// A collection of [`Plugin`] structures describing each plugin discovered on
+/// disk.
 pub fn list_plugins() -> Vec<Plugin> {
     audio_engine::plugins::PluginHost::scan()
 }


### PR DESCRIPTION
## Summary
- expand function docs for `lib.rs`
- describe side effects in `DeviceManager`
- document `PluginHost` constructors and scanning behavior

## Testing
- `pnpm lint`
- `pnpm --filter frontend test -- --run`
- `pnpm --filter frontend exec playwright test`
- `pnpm --filter frontend build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_686a42f37de083289ed741ce199064a4