### PR TITLE
Add theme toggle

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",
     "zod": "^3.25.74",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "@tabler/icons-react": "^2.36.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.2",

--- a/packages/frontend/src/__tests__/ThemeToggle.test.tsx
+++ b/packages/frontend/src/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,37 @@
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { MantineProvider } from '@mantine/core';
+import ThemeToggle from '../components/ThemeToggle';
+import { useStore } from '../state/useStore';
+
+describe('ThemeToggle', () => {
+  beforeAll(() => {
+    class RO { observe(){} unobserve(){} disconnect(){} }
+    // @ts-expect-error polyfill
+    global.ResizeObserver = RO;
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it('toggles color scheme', () => {
+    useStore.setState({ colorScheme: 'light' });
+    const { getByRole } = render(
+      <MantineProvider>
+        <ThemeToggle />
+      </MantineProvider>
+    );
+    fireEvent.click(getByRole('button', { name: /toggle theme/i }));
+    expect(useStore.getState().colorScheme).toBe('dark');
+  });
+});

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -3,10 +3,12 @@ import { Notifications } from '@mantine/notifications';
 import { Routes, Route } from 'react-router-dom';
 import Home from './routes/home';
 import PluginList from './components/PluginList';
+import { useStore } from './state/useStore';
 
 export default function App() {
+  const scheme = useStore((s) => s.colorScheme);
   return (
-    <MantineProvider withNormalizeCSS withGlobalStyles>
+    <MantineProvider withNormalizeCSS withGlobalStyles theme={{ colorScheme: scheme }}>
       <Notifications />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/packages/frontend/src/components/ThemeToggle.tsx
+++ b/packages/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,14 @@
+import { ActionIcon } from '@mantine/core';
+import { IconSun, IconMoonStars } from '@tabler/icons-react';
+import { useStore } from '../state/useStore';
+
+export default function ThemeToggle() {
+  const scheme = useStore((s) => s.colorScheme);
+  const toggle = useStore((s) => s.toggleColorScheme);
+  const dark = scheme === 'dark';
+  return (
+    <ActionIcon onClick={toggle} variant="outline" aria-label="Toggle theme">
+      {dark ? <IconSun size={16} /> : <IconMoonStars size={16} />}
+    </ActionIcon>
+  );
+}

--- a/packages/frontend/src/routes/home.tsx
+++ b/packages/frontend/src/routes/home.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import TrackList from '../components/TrackList';
 import Mixer from '../components/Mixer';
 import DeviceSelector from '../components/DeviceSelector';
+import ThemeToggle from '../components/ThemeToggle';
 import { useStore } from '../state/useStore';
 
 export default function Home() {
@@ -31,7 +32,10 @@ export default function Home() {
 
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Bitmxr</h1>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold">Bitmxr</h1>
+        <ThemeToggle />
+      </div>
       <Button onClick={getStats} className="mr-2">Get Audio Stats</Button>
       {stats && <p className="mt-2">{stats}</p>}
       <div className="mt-4">

--- a/packages/frontend/src/state/useStore.ts
+++ b/packages/frontend/src/state/useStore.ts
@@ -10,21 +10,28 @@ export interface AudioDevice {
   name: string;
 }
 
+export type ColorScheme = 'light' | 'dark';
+
 interface StoreState {
   tracks: Track[];
   selectedDevice?: AudioDevice;
+  colorScheme: ColorScheme;
   addTrack: (track: Track) => void;
   removeTrack: (id: string) => void;
   setDevice: (device: AudioDevice) => void;
+  toggleColorScheme: () => void;
 }
 
 export const useStore = create<StoreState>((set) => ({
   tracks: [],
   selectedDevice: undefined,
+  colorScheme: 'light',
   addTrack: (track) =>
     set((state) => ({ tracks: [...state.tracks, track] })),
   removeTrack: (id) =>
     set((state) => ({ tracks: state.tracks.filter((t) => t.id !== id) })),
   setDevice: (device) => set({ selectedDevice: device }),
+  toggleColorScheme: () =>
+    set((state) => ({ colorScheme: state.colorScheme === 'light' ? 'dark' : 'light' })),
 }));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@mantine/notifications':
         specifier: ^8.1.2
         version: 8.1.2(@mantine/core@8.1.2(@mantine/hooks@8.1.2(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@mantine/hooks@8.1.2(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@tabler/icons-react':
+        specifier: ^2.36.0
+        version: 2.47.0(react@19.1.0)
       '@tauri-apps/api':
         specifier: ^2.6.0
         version: 2.6.0
@@ -732,6 +735,14 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@tabler/icons-react@2.47.0':
+    resolution: {integrity: sha512-iqly2FvCF/qUbgmvS8E40rVeYY7laltc5GUjRxQj59DuX0x/6CpKHTXt86YlI2whg4czvd/c8Ce8YR08uEku0g==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  '@tabler/icons@2.47.0':
+    resolution: {integrity: sha512-4w5evLh+7FUUiA1GucvGj2ReX2TvOjEr4ejXdwL/bsjoSkof6r1gQmzqI+VHrE2CpJpB3al7bCTulOkFa/RcyA==}
 
   '@tailwindcss/node@4.1.11':
     resolution: {integrity: sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==}
@@ -3395,6 +3406,14 @@ snapshots:
       storybook: 9.0.15(@testing-library/dom@10.4.0)(prettier@3.6.2)
     optionalDependencies:
       typescript: 5.8.3
+
+  '@tabler/icons-react@2.47.0(react@19.1.0)':
+    dependencies:
+      '@tabler/icons': 2.47.0
+      prop-types: 15.8.1
+      react: 19.1.0
+
+  '@tabler/icons@2.47.0': {}
 
   '@tailwindcss/node@4.1.11':
     dependencies:


### PR DESCRIPTION
## Summary
- add color scheme state and toggle hook
- add ThemeToggle component and integrate on Home page
- wrap MantineProvider with color scheme from store
- include basic tests for ThemeToggle
- update dependencies

## Testing
- `pnpm lint`
- `pnpm --filter frontend test -- --run`
- `pnpm --filter frontend exec playwright test` *(fails: Test timeout of 30000ms exceeded)*
- `pnpm --filter frontend build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_686a45de63848328b0d01db4dd155b6a