### PR TITLE
Add project persistence support

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,13 +17,14 @@
     "@mantine/core": "^8.1.2",
     "@mantine/hooks": "^8.1.2",
     "@mantine/notifications": "^8.1.2",
+    "@tabler/icons-react": "^2.36.0",
     "@tauri-apps/api": "^2.6.0",
+    "@tauri-apps/plugin-dialog": "^2.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",
     "zod": "^3.25.74",
-    "zustand": "^5.0.6",
-    "@tabler/icons-react": "^2.36.0"
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.2",

--- a/packages/frontend/src/__tests__/store.test.ts
+++ b/packages/frontend/src/__tests__/store.test.ts
@@ -16,5 +16,14 @@ describe('store', () => {
     useStore.getState().removeTrack('1');
     expect(useStore.getState().tracks).toHaveLength(0);
   });
+
+  it('sets track list', () => {
+    useStore.getState().setTracks([
+      { id: '2', name: 'A' },
+      { id: '3', name: 'B' },
+    ]);
+    expect(useStore.getState().tracks).toHaveLength(2);
+    expect(useStore.getState().tracks[0].name).toBe('A');
+  });
 });
 

--- a/packages/frontend/src/routes/home.tsx
+++ b/packages/frontend/src/routes/home.tsx
@@ -1,5 +1,7 @@
 import { Button, Text } from '@mantine/core';
 import { invoke } from '@tauri-apps/api/core';
+import { open, save } from '@tauri-apps/plugin-dialog';
+import type { Project } from '../types';
 import { useEffect, useState } from 'react';
 import TrackList from '../components/TrackList';
 import Mixer from '../components/Mixer';
@@ -11,6 +13,8 @@ export default function Home() {
   const [stats, setStats] = useState<string>('');
   const [devices, setDevices] = useState<string[]>([]);
   const selected = useStore((state) => state.selectedDevice);
+  const tracks = useStore((state) => state.tracks);
+  const setTracks = useStore((state) => state.setTracks);
 
   async function getStats() {
     const result = await invoke<string>('get_audio_stats');
@@ -26,6 +30,27 @@ export default function Home() {
     }
   }
 
+  async function handleSave() {
+    try {
+      const path = await save({ filters: [{ name: 'Bitmxr Project', extensions: ['bmxr'] }] });
+      if (!path) return;
+      await invoke('save_project', { path, project: { version: 1, tracks } });
+    } catch {
+      // ignore errors in non-tauri environments
+    }
+  }
+
+  async function handleLoad() {
+    try {
+      const path = await open({ filters: [{ name: 'Bitmxr Project', extensions: ['bmxr'] }] });
+      if (!path || Array.isArray(path)) return;
+      const project = await invoke<Project>('load_project', { path });
+      setTracks(project.tracks);
+    } catch {
+      // ignore errors in non-tauri environments
+    }
+  }
+
   useEffect(() => {
     getDevices();
   }, []);
@@ -36,7 +61,11 @@ export default function Home() {
         <h1 className="text-2xl font-bold">Bitmxr</h1>
         <ThemeToggle />
       </div>
-      <Button onClick={getStats} className="mr-2">Get Audio Stats</Button>
+      <div className="space-x-2 mb-2">
+        <Button onClick={getStats}>Get Audio Stats</Button>
+        <Button onClick={handleSave}>Save Project</Button>
+        <Button onClick={handleLoad}>Load Project</Button>
+      </div>
       {stats && <p className="mt-2">{stats}</p>}
       <div className="mt-4">
         <DeviceSelector devices={devices} />

--- a/packages/frontend/src/state/useStore.ts
+++ b/packages/frontend/src/state/useStore.ts
@@ -18,6 +18,7 @@ interface StoreState {
   colorScheme: ColorScheme;
   addTrack: (track: Track) => void;
   removeTrack: (id: string) => void;
+  setTracks: (tracks: Track[]) => void;
   setDevice: (device: AudioDevice) => void;
   toggleColorScheme: () => void;
 }
@@ -30,6 +31,7 @@ export const useStore = create<StoreState>((set) => ({
     set((state) => ({ tracks: [...state.tracks, track] })),
   removeTrack: (id) =>
     set((state) => ({ tracks: state.tracks.filter((t) => t.id !== id) })),
+  setTracks: (tracks) => set({ tracks }),
   setDevice: (device) => set({ selectedDevice: device }),
   toggleColorScheme: () =>
     set((state) => ({ colorScheme: state.colorScheme === 'light' ? 'dark' : 'light' })),

--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -1,0 +1,6 @@
+import type { Track } from './state/useStore';
+
+export interface Project {
+  version: number;
+  tracks: Track[];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.3.0
+        version: 2.3.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.11
@@ -32,6 +36,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.6.0
         version: 2.6.0
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.3.0
+        version: 2.3.0
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -905,6 +912,9 @@ packages:
     resolution: {integrity: sha512-s1/eyBHxk0wG1blLeOY2IDjgZcxVrkxU5HFL8rNDwjYGr0o7yr3RAtwmuUPhz13NO+xGAL1bJZaLFBdp+5joKg==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.3.0':
+    resolution: {integrity: sha512-ylSBvYYShpGlKKh732ZuaHyJ5Ie1JR71QCXewCtsRLqGdc8Is4xWdz6t43rzXyvkItM9syNPMvFVcvjgEy+/GA==}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -3535,6 +3545,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.6.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.6.2
       '@tauri-apps/cli-win32-x64-msvc': 2.6.2
+
+  '@tauri-apps/plugin-dialog@2.3.0':
+    dependencies:
+      '@tauri-apps/api': 2.6.0
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod audio_engine;
+pub mod project;
+
 pub use audio_engine::plugins::Plugin;
+pub use project::{load_project, save_project, Project, Track};
 
 /// Return placeholder audio statistics used by the Tauri commands.
 ///
@@ -40,4 +43,24 @@ pub fn set_audio_device(id: &str) {
 /// disk.
 pub fn list_plugins() -> Vec<Plugin> {
     audio_engine::plugins::PluginHost::scan()
+}
+
+/// Save a project definition to disk.
+///
+/// # Arguments
+/// * `path` - Destination file path.
+/// * `project` - Project data to persist.
+pub fn save_project_file(path: &std::path::Path, project: &Project) -> std::io::Result<()> {
+    project::save_project(path, project)
+}
+
+/// Load a project definition from disk.
+///
+/// # Arguments
+/// * `path` - Source file path.
+///
+/// # Returns
+/// Parsed [`Project`] structure on success.
+pub fn load_project_file(path: &std::path::Path) -> std::io::Result<Project> {
+    project::load_project(path)
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,7 +3,8 @@
 use bitmxr::{
     audio_engine::AudioEngine, get_audio_stats as get_audio_stats_impl,
     list_audio_devices as list_audio_devices_impl, list_plugins as list_plugins_impl,
-    set_audio_device as set_audio_device_impl, Plugin,
+    load_project_file as load_project_file_impl, save_project_file as save_project_file_impl,
+    set_audio_device as set_audio_device_impl, Plugin, Project,
 };
 
 #[tauri::command]
@@ -26,6 +27,16 @@ fn set_audio_device(id: String) {
     set_audio_device_impl(&id);
 }
 
+#[tauri::command]
+fn save_project(path: String, project: Project) -> Result<(), String> {
+    save_project_file_impl(std::path::Path::new(&path), &project).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn load_project(path: String) -> Result<Project, String> {
+    load_project_file_impl(std::path::Path::new(&path)).map_err(|e| e.to_string())
+}
+
 fn main() {
     tracing_subscriber::fmt::init();
     tauri::Builder::default()
@@ -34,7 +45,9 @@ fn main() {
             get_audio_stats,
             list_audio_devices,
             set_audio_device,
-            list_plugins
+            list_plugins,
+            save_project,
+            load_project
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -1,0 +1,40 @@
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Simple project representation persisted to disk as JSON.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Project {
+    /// Version number for future migration.
+    pub version: u8,
+    /// List of tracks in this project.
+    pub tracks: Vec<Track>,
+}
+
+impl Default for Project {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            tracks: Vec::new(),
+        }
+    }
+}
+
+/// Track entry saved inside a project file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Track {
+    pub id: String,
+    pub name: String,
+}
+
+/// Write the project data to the given path in JSON format.
+pub fn save_project(path: &Path, project: &Project) -> std::io::Result<()> {
+    let bytes = serde_json::to_vec_pretty(project)?;
+    std::fs::write(path, bytes)
+}
+
+/// Load a project from the provided path.
+pub fn load_project(path: &Path) -> std::io::Result<Project> {
+    let bytes = std::fs::read_to_string(path)?;
+    let project = serde_json::from_str(&bytes)?;
+    Ok(project)
+}

--- a/src-tauri/tests/project.rs
+++ b/src-tauri/tests/project.rs
@@ -1,0 +1,17 @@
+use bitmxr::{load_project_file, save_project_file, Project, Track};
+
+#[test]
+fn save_and_load_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.bmxr");
+    let project = Project {
+        version: 1,
+        tracks: vec![Track {
+            id: "1".into(),
+            name: "Track 1".into(),
+        }],
+    };
+    save_project_file(&path, &project).unwrap();
+    let loaded = load_project_file(&path).unwrap();
+    assert_eq!(loaded, project);
+}


### PR DESCRIPTION
## Summary
- implement Project save/load in Rust backend
- expose new `save_project` and `load_project` Tauri commands
- add `setTracks` action to frontend store with tests
- wire up save/load buttons in the Home page UI
- install `@tauri-apps/plugin-dialog` and reference new `Project` type
- include tests for project round trip

## Testing
- `pnpm lint`
- `pnpm --filter frontend test -- --run`
- `pnpm --filter frontend exec playwright test`
- `pnpm --filter frontend build`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_686a49c6f07c8328a5a03eda1bac4e54